### PR TITLE
Try using PyPI tarball to avoid intermittent server failures.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,11 +8,11 @@ package:
 
 source:
   fn: {{ name }}-{{ version }}.tar.gz
-  url: https://glotzerlab.engin.umich.edu/Downloads/{{ name }}/{{ name }}-v{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   script: "{{ PYTHON }} -m pip install . --ignore-installed --no-cache-dir -vv"
   skip: true  # [py<35]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "freud" %}
 {% set version = "2.0.1" %}
-{% set sha256 = "332bc720ad6de2cebafe7999ce21d42024e858a5e79d53b8d269111a05ec779a" %}
+{% set sha256 = "9fa803a6e7ae26dc8fb2e5717f1ee6aa09376c289eab3c0ce9d44352aeaed9b6" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,7 +8,7 @@ package:
 
 source:
   fn: {{ name }}-{{ version }}.tar.gz
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/f/freud-analysis/freud-analysis-{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:


### PR DESCRIPTION
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Some builds have been failing recently due to our webserver rejecting requests for downloading tarballs. This PR switches to using tarballs from PyPI instead.